### PR TITLE
📝 docs(contributing): fix pr template link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ For **merge commits**, use this format:
 
 ## 🚀 Pull Request Requirements
 
-All PRs must use the standard [PR Template](./project-docs/pr-template.md). It includes:
+All PRs must use the standard [PR Template](.github/pull_request_template.md). This template is automatically pre-filled when creating a PR via GitHub and includes:
 
 - **What was done:** Begin with `This PR introduces:` followed by bullet points
 - **Why it matters:** Describe the problem and importance of the fix or feature


### PR DESCRIPTION
### ✍️ What was done

This PR fixes the link to the pull request template in the CONTRIBUTING.md file.

* Updated the reference to the PR template to point to the correct path.

### 📌 Why it matters

Without this change, contributors might not find the correct PR template, leading to inconsistent PR descriptions.

This improvement ensures that the documentation accurately guides contributors to the proper template.

### 🧪 How to test

1. Open CONTRIBUTING.md
2. Check the link under "Pull Request Requirements" points to `.github/pull_request_template.md`
3. Verify the link is functional

### 📎 Related

No related issues.