### PR TITLE
📝 docs(pr-template): comment out merge guidelines reference

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -70,8 +70,8 @@ No related issues, but this prepares ground for future improvements to DevContai
 Closes #...
 Depends on #...
 
----
+<!--
 
-> ℹ️ Please squash unnecessary commits before requesting a review.
->
-> 📚 Refer to `project-docs/merge-commit-guidelines.md` for commit message standards when merging.
+📚 Refer to `project-docs/merge-commit-guidelines.md` for commit message standards when merging.
+
+-->


### PR DESCRIPTION
### ✍️ What was done

This PR updates the pull request template to comment out the reference to merge guidelines.

* Commented out the reference to `project-docs/merge-commit-guidelines.md` in the PR template

### 📌 Why it matters

Without this change, the PR template included a reference that may be outdated or unnecessary.

This improvement ensures the template remains clean and relevant for contributors.

### 🧪 How to test

1. Create a new PR and verify the template doesn't show the commented out section.

### 📎 Related

No related issues.