### PR TITLE
✨ feat(home): add About page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,18 @@
+export default function AboutPage() {
+  return (
+    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
+      <main className="flex flex-col gap-[16px] row-start-2 items-center sm:items-start max-w-prose">
+        <h1 className="text-3xl font-semibold tracking-tight">About Us</h1>
+        <p className="text-base text-gray-700">
+          AI Playlist Generator helps you create personalized Spotify playlists
+          using AI. We analyze your music preferences to curate tracks that
+          match your taste and mood.
+        </p>
+        <p className="text-base text-gray-700">
+          This is an open-source project. Contributions, feedback, and ideas are
+          welcome!
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
@@ -19,6 +20,19 @@ export default function Home() {
         </ol>
       </main>
       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
+        <Link
+          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
+          href="/about"
+        >
+          <Image
+            aria-hidden
+            src="/file.svg"
+            alt="Document icon"
+            width={16}
+            height={16}
+          />
+          About Us
+        </Link>
         <a
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
           href="https://github.com/lgdevlop/spotify-playlist"


### PR DESCRIPTION
✍️ What was done
This PR adds a public About page to introduce the product and invite contributions.
Created app/about/page.tsx with responsive layout and typography
Added clear product overview and open-source contribution invite copy
Ensured fonts/styles are consistent with RootLayout and global styles
📌 Why it matters
Users need a quick way to understand what AI Playlist Generator does and how to get involved. Having an About page improves product clarity, credibility, and community onboarding for contributors.
🧪 How to test
Run the dev server: pnpm dev or npm run dev
Navigate to http://localhost:3000/about
Verify:
The page renders the heading “About Us”
Two paragraphs appear describing the product and inviting contributions
Typography and spacing match the rest of the site (fonts from RootLayout apply)
Page is responsive on mobile and desktop (grid/spacing adjusts via Tailwind classes)