### PR TITLE
🔧 chore(eslint): ignore temp directory

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ const eslintConfig = [
       "out/**",
       "build/**",
       "next-env.d.ts",
+      "temp/**",
     ],
   },
 ];


### PR DESCRIPTION
### ✍️ What was done

This PR adds the `temp/**` directory to the ESLint ignore patterns in `eslint.config.mjs` to prevent linting errors on temporary files that may be generated during development.

* Added `"temp/**"` to the ignore patterns in `eslint.config.mjs`
* Ensures temporary files don't trigger ESLint warnings or errors

### 📌 Why it matters

Without this change, any temporary files created in the `temp/` directory would be processed by ESLint, potentially causing unnecessary linting errors and warnings during development. This improvement ensures a cleaner development experience by excluding temporary files from linting while maintaining code quality standards for the actual source code.

### 🧪 How to test

1. Create a temporary file in the `temp/` directory with JavaScript/TypeScript content that would normally trigger ESLint errors
2. Run ESLint on the project: `bun run lint` or `bunx eslint .`
3. Verify that the temporary file in `temp/` is ignored and no linting errors are reported for it
4. Verify that ESLint still properly lint files in other directories

### 📎 Related

Closes #34
