### PR TITLE
🤖 ci(bun): update setup action and pin version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.2.22"
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
### ✍️ What was done

This PR updates the Bun setup action in the CI workflow to use the latest version and pins the Bun runtime version for consistent builds.

* Updated `oven-sh/setup-bun` action from v1 to v2
* Pinned Bun version from `latest` to `1.2.22` for build consistency

### 📌 Why it matters

Without this change, the CI workflow uses an unpinned Bun version which can lead to inconsistent builds and potential failures when new Bun versions are released. This improvement ensures that:

* Builds are reproducible and predictable
* Dependencies resolve consistently across different CI runs
* The workflow is protected from breaking changes in newer Bun versions

### 🧪 How to test

1. Push a commit to trigger the CI workflow
2. Verify that the workflow uses Bun version 1.2.22
3. Confirm that all tests pass and the build completes successfully
4. Check that the setup action uses v2 instead of v1

### 📎 Related

No related issues, but this improves CI stability and build consistency.
